### PR TITLE
Change package scrpage2 to successor scrlayer-scrpage

### DIFF
--- a/geneve_1564.tex
+++ b/geneve_1564.tex
@@ -133,7 +133,7 @@
 
 
 % Headings
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 \rofoot[]{}
 \ohead[\pagemark]{\pagemark}
 


### PR DESCRIPTION
I had to use the new package to be able to compile the document with TeX Live 2022

Cf. https://tex.stackexchange.com/a/541772/38905